### PR TITLE
Add mechanism to handle app changelogs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,17 @@ en:
   troubleshooting: "Troubleshooting"
   description: "Learn how to create, deploy and manage CloudWalk apps."
   copy: "Copy"
+  version: "Version"
+  apps:
+    globalpayments:
+      title: "Global Payments"
+      description: "Payment application from Global Payments"
+      intro: "Payment application from Global Payments"
+      versions:
+        1.0.0:
+          date: "06/22/2015"
+          changelog:
+            paragraph_1: "First release"
   api:
     description: Description
     method: Method and URL format

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -2,6 +2,17 @@ pt-BR:
   troubleshooting: "Resolução de problemas"
   description: "Aprenda a criar, publicar e gerenciar aplicações CloudWalk."
   copy: "Copiar"
+  version: "Versão"
+  apps:
+    globalpayments:
+      title: "Global Payments"
+      description: "Aplicação de pagamentos Global Payments"
+      intro: "Aplicação de pagamentos Global Payments"
+      versions:
+        1.0.0:
+          date: "22/06/2015"
+          changelog:
+            paragraph_1: "Primeiro release"
   api:
     description: Descrição
     method: Método e formato da URL

--- a/routes.rb
+++ b/routes.rb
@@ -55,8 +55,10 @@ class Routes
       { "url" => "guides/transactions-patterns/patterns-chart",          "view_path" => "guides/transactions_patterns/tutorial_3_patterns_chart"},
       { "url" => "guides/transactions-patterns/notifications-settings",  "view_path" => "guides/transactions_patterns/tutorial_4_notifications_settings"},
       { "url" => "guides/emulator-card-swipe",                           "view_path" => "guides/emulator_card_swipe"},
-      #HELP
+      # HELP
       { "url" => "help/faq",                                             "view_path" => "help/faq"},
+      # POSXML APPS CHANGELOG
+      { "url" => "apps/globalpayments",                                  "view_path" => "apps/globalpayments"},
     ]
   end
 

--- a/templates/apps/globalpayments.erb
+++ b/templates/apps/globalpayments.erb
@@ -1,0 +1,19 @@
+<% content_for :docs_description do %>
+  <meta name="docs:description" content="<%= I18n.t('apps.globalpayments.description') %>">
+<% end %>
+
+<h1><%= I18n.t("apps.globalpayments.title") %></h1>
+
+<p class="intro"><%= I18n.t("apps.globalpayments.intro") %></p>
+
+<h2>Changelog</h2>
+
+<% I18n.t("apps.globalpayments.versions").each do |entry| %>
+  <h3><%= entry[1][:date] %>: <%= I18n.t("version") %> <strong><%= entry[0] %></strong></h3>
+
+  <ul>
+    <% entry[1][:changelog].each do |item| %>
+      <li><%= item[1] %></li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
CC: @scalone @williamrgt @ccorrea255 

The mechanism relies purely on the translation files (`en.yml` and `pt-BR.yml`), so it is not necessary to ever update the page itself.

For example, considering the first release, the `en.yml` file is defined like this:

```
  apps:
    globalpayments:
      title: "Global Payments"
      description: "Payment application from Global Payments"
      intro: "Payment application from Global Payments"
      versions:
        1.0.0:
          date: "06/22/2015"
          changelog:
            paragraph_1: "First release"
```

Now, let's create a fictional version 1.0.1:

```
  apps:
    globalpayments:
      title: "Global Payments"
      description: "Payment application from Global Payments"
      intro: "Payment application from Global Payments"
      versions:
        1.0.0:
          date: "06/22/2015"
          changelog:
            paragraph_1: "First release"
        1.0.1:
          date: "06/29/2015"
          changelog:
            paragraph_1: "Fix receipt typo;"
            paragraph_2: "Improve boot speed;"
```