### PR TITLE
Improve Telium 1/2 steps for pendrive preparation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2830,7 +2830,7 @@ en:
         paragraph_2: Connect the USB pendrive to the computer
         paragraph_3: Format the USB stick
         paragraph_4: Extract the CloudWalk Framework package that was downloaded at the beginning of this tutorial
-        paragraph_5: In the unzipped folder you will find a folder called 'CloudCloudWalk Framework', copy the folder called Telium lying in it for pendrive
+        paragraph_5: In the unzipped folder open the folder 'Framework' and copy the folder Telium to the pendrive
       prerequisites:
         adapter: <strong>USB adapter:</strong> Required for installation. It is possible to purchase one with your supplier.
         operating_system: <strong>Operating System:</strong> Microsoft Windows XP SP3 or newer (Vista, Seven, etc)
@@ -2874,7 +2874,7 @@ en:
         paragraph_2: Connect the USB pendrive to the computer
         paragraph_3: Format the pendrive
         paragraph_4: Extract the CloudWalk Framework downloaded at the beginning of this tutorial
-        paragraph_5: n the unzipped folder you will find a folder called 'CloudCloudWalk Framework', copy the folder called Telium lying in it for pendrive
+        paragraph_5: In the unzipped folder open the folder 'Framework' and copy the folder Telium to the pendrive
       prerequisites:
         adapter: '<strong>USB Adapter:</strong> Required only for installation on IWL220, IWL250 and IWL280'
         operating_system: '<strong>Operating System:</strong> Microsoft Windows XP SP3 or later.'

--- a/config/locales/pt-br.yml
+++ b/config/locales/pt-br.yml
@@ -2830,7 +2830,7 @@ pt-BR:
         paragraph_2: Conecte o pendrive no computador
         paragraph_3: Formate o pendrive
         paragraph_4: Extraia o pacote do CloudWalk Framework baixado no inicio deste tutorial
-        sparagraph_5: Na pasta descompactada você irá encontrar uma pasta chamada 'CloudCloudWalk Framework', copie a pasta chamada TELIUM que se encontra nela para o pendrive
+        paragraph_5: Na pasta descompactada abra a pasta 'Framework' e copie a pasta TELIUM para o pendrive
       prerequisites:
         adapter: <strong>Adaptador USB:</strong> Necessário para fazer a instalação, é possível conseguir com o seu fornecedor.
         operating_system: <strong>Sistema operacional:</strong> Microsoft Windows XP SP3 ou superior (Vista, Seven, etc)
@@ -2874,7 +2874,7 @@ pt-BR:
         paragraph_2: Conecte o pendrive no computador
         paragraph_3: Formate o pendrive
         paragraph_4: Extraia o pacote do CloudWalk Framework baixado no inicio deste tutorial
-        paragraph_5: Na pasta descompactada você irá encontrar uma pasta chamada 'CloudCloudWalk Framework', copie a pasta chamada TELIUM que se encontra nela para o pendrive
+        paragraph_5: Na pasta descompactada abra a pasta 'Framework' e copie a pasta TELIUM para o pendrive
       prerequisites:
         adapter: <strong>Adaptador USB:</strong> Necessário somente para fazer a instalação no IWL220, IWL250 e IWL280
         operating_system: <strong>Sistema operacional:</strong> Microsoft Windows XP SP3 ou superior (Vista, Seven, etc)


### PR DESCRIPTION
The current documentation for Telium 1 and 2 are wrong in the steps about preparing the pendrive.

https://docs.cloudwalk.io/en/framework/ingenico-telium-2
https://docs.cloudwalk.io/en/framework/ingenico-telium-1

In the English and Portuguese versions is says:

`...you will find a folder called 'CloudCloudWalk Framework', copy the folder called Telium lying in it for pendrive`

But in the downloaded ZIP the folder is called `Framework`.

And also a fix for a small typo: `n` instead of `In` and improved the sentences removing some unnecessary words.
